### PR TITLE
Manage message as an io list or string

### DIFF
--- a/lib/interface.ex
+++ b/lib/interface.ex
@@ -14,7 +14,11 @@ defmodule Logger.Formatter.Interface do
         ) :: IO.chardata()
   def format(level, message, time, metadata) do
     Map.new(metadata)
-    |> Map.merge(%{"msg" => clean_message(message), "level" => level, "ts" => fmt_dt(time)})
+    |> Map.merge(%{
+      "msg" => :erlang.iolist_to_binary(message),
+      "level" => level,
+      "ts" => fmt_dt(time)
+    })
     |> Application.fetch_env!(:logger, :encoder).encode!()
   rescue
     error ->
@@ -24,16 +28,6 @@ defmodule Logger.Formatter.Interface do
       }"}
       """
   end
-
-  defp clean_message(message) when is_list(message) do
-    message
-    |> List.flatten()
-    |> Enum.filter(&is_binary/1)
-    |> Enum.reduce("", fn x, acc -> "#{acc} #{x}" end)
-    |> String.trim()
-  end
-
-  defp clean_message(message), do: message
 
   defp fmt_dt({date, time}) do
     "#{Logger.Formatter.format_date(date)} #{Logger.Formatter.format_time(time)}"

--- a/test/interface_test.exs
+++ b/test/interface_test.exs
@@ -9,6 +9,7 @@ end
 defmodule EncoderExpecter do
   def encode!(map) do
     if map["ts"] != "2014-12-30 12:06:30.100", do: raise("ts not ok")
+
     if map["msg"] != "hello world", do: raise("msg not ok")
     if map["level"] != :error, do: raise("level not ok")
     if map[:foo] == nil, do: raise("foo not ok")
@@ -16,12 +17,16 @@ defmodule EncoderExpecter do
   end
 end
 
+defmodule PipeEncoder do
+  def encode!(map), do: map["msg"]
+end
+
 defmodule Logger.Formatter.InterfaceTest do
   use ExUnit.Case
 
   alias Logger.Formatter.Interface
 
-  test "work" do
+  test "log record without metadata" do
     Application.put_env(:logger, :encoder, DummyEncoderSuccess)
 
     assert Interface.format(nil, nil, nil, nil) ==
@@ -33,26 +38,87 @@ defmodule Logger.Formatter.InterfaceTest do
     assert Interface.format(:error, "hello world", nil, nil) ==
              "{\"msg\": \"could not format: {:error, \"hello world\", nil, nil}\", \"error\": {%Protocol.UndefinedError{description: \"\", protocol: Enumerable, value: nil}}\"}\n"
 
-    ts = {{2014, 12, 30}, {12, 6, 30, 100}}
-
-    assert Interface.format(:error, "hello world", ts, nil) ==
+    assert Interface.format(:error, "hello world", {{2014, 12, 30}, {12, 6, 30, 100}}, nil) ==
              "{\"msg\": \"could not format: {:error, \"hello world\", {{2014, 12, 30}, {12, 6, 30, 100}}, nil}\", \"error\": {%Protocol.UndefinedError{description: \"\", protocol: Enumerable, value: nil}}\"}\n"
+  end
 
-    assert Interface.format(:error, "hello world", ts, []) == ""
+  test "log record with all requirements" do
+    Application.put_env(:logger, :encoder, DummyEncoderSuccess)
+    assert Interface.format(:error, "hello world", {{2014, 12, 30}, {12, 6, 30, 100}}, []) == ""
 
-    assert Interface.format(:error, "hello world", ts, foo: "bar") == ""
+    assert Interface.format(:error, "hello world", {{2014, 12, 30}, {12, 6, 30, 100}}, foo: "bar") ==
+             ""
+  end
 
+  test "log record with a invalid encoder" do
     Application.put_env(:logger, :encoder, DummyEncoderFail)
 
-    assert Interface.format(:error, "hello world", ts, foo: "bar") ==
+    assert Interface.format(:error, "hello world", {{2014, 12, 30}, {12, 6, 30, 100}}, foo: "bar") ==
              "{\"msg\": \"could not format: {:error, \"hello world\", {{2014, 12, 30}, {12, 6, 30, 100}}, [foo: \"bar\"]}\", \"error\": {%RuntimeError{message: \"foo\"}}\"}\n"
+  end
 
+  test "formatter output" do
     Application.put_env(:logger, :encoder, EncoderExpecter)
 
-    assert Interface.format(:error, "hello world", ts, foo: "bar") == ""
+    assert Interface.format(:error, "hello world", {{2014, 12, 30}, {12, 6, 30, 100}}, foo: "bar") ==
+             ""
 
-    assert Interface.format(:error, "hello world", ts, foo: "bar", ts: "foobar") == ""
+    assert Interface.format(
+             :error,
+             "hello world",
+             {{2014, 12, 30}, {12, 6, 30, 100}},
+             foo: "bar",
+             ts: "foobar"
+           ) == ""
 
-    assert Interface.format(:error, ["hello", 32, ["world"]], ts, foo: "bar") == ""
+    assert Interface.format(
+             :error,
+             ["hello", 32, ["world"]],
+             {{2014, 12, 30}, {12, 6, 30, 100}},
+             foo: "bar"
+           ) == ""
+  end
+
+  test "message cleanup with a list" do
+    Application.put_env(:logger, :encoder, PipeEncoder)
+
+    assert Interface.format(
+             :error,
+             [
+               "QUERY",
+               32,
+               "OK",
+               "",
+               [32, "db", 61, '1.8', 109, 115],
+               [],
+               [32, "queue", 61, '94.1', 109, 115],
+               10,
+               "SELECT relname FROM pg_class WHERE relname = 'keys'",
+               32,
+               "[]"
+             ],
+             {{2014, 12, 30}, {12, 6, 30, 100}},
+             foo: "bar"
+           ) ==
+             "QUERY OK db=1.8ms queue=94.1ms\nSELECT relname FROM pg_class WHERE relname = 'keys' []"
+  end
+
+  test "message cleanup with an improperlist" do
+    Application.put_env(:logger, :encoder, PipeEncoder)
+
+    assert Interface.format(
+             :error,
+             [
+               "Postgrex.Protocol",
+               32,
+               40,
+               "#PID<0.1937.0>",
+               ") failed to connect: "
+               | "** (Postgrex.Error) FATAL 3D000 (invalid_catalog_name): database \"db\" does not exist"
+             ],
+             {{2018, 10, 18}, {9, 48, 35, 571}},
+             []
+           ) ==
+             "Postgrex.Protocol (#PID<0.1937.0>) failed to connect: ** (Postgrex.Error) FATAL 3D000 (invalid_catalog_name): database \"db\" does not exist"
   end
 end


### PR DESCRIPTION
The message can be a binary (String) or an iolist (List or an improper List).
:erlang.iolist_to_binary seems to be the better solution in our case: [iolist_to_binary doc](http://erlang.org/doc/man/erlang.html#iolist_to_binary-1)

**Reminder**
a list `[1 | [2]`
an improper list `[1 | 2]`